### PR TITLE
Renamed RESET to ENCODER_RESET > name collision

### DIFF
--- a/examples/I2CEncoderV2/LCD_with_RGB_encoder/LCD_with_RGB_encoder.ino
+++ b/examples/I2CEncoderV2/LCD_with_RGB_encoder/LCD_with_RGB_encoder.ino
@@ -55,7 +55,7 @@ void setup(void)
 {
   Wire.begin();
   Wire.setClock(400000);
-  RGBEncoder.reset();
+  RGBEncoder.ENCODER_RESET();
 
   delay(1000);
   pinMode(IntPin, INPUT);

--- a/src/i2cEncoderLibV2.cpp
+++ b/src/i2cEncoderLibV2.cpp
@@ -28,7 +28,7 @@ void i2cEncoderLibV2::begin(uint8_t conf) {
 	_gconf = conf;
 }
 
-void i2cEncoderLibV2::reset(void) {
+void i2cEncoderLibV2::ENCODER_RESET(void) {
 	writeEncoder(REG_GCONF, (uint8_t) 0x80);
 	delay(10);
 }

--- a/src/i2cEncoderLibV2.h
+++ b/src/i2cEncoderLibV2.h
@@ -83,7 +83,7 @@ enum GCONF_PARAMETER {
   EEPROM_BANK1 =  0x40,
   EEPROM_BANK2 =  0x00,
   
-  RESET =  0x80,
+  ENCODER_RESET =  0x80,
 };
 
 /* Encoder status bits and setting. Use with: INTCONF for set and with ESTATUS for read the bits  */
@@ -170,7 +170,7 @@ class i2cEncoderLibV2
     /** Configuration function **/
     i2cEncoderLibV2(uint8_t add);
 	void begin( uint8_t conf);
-    void reset(void);
+    void ENCODER_RESET(void);
     
     /** Configuration of callback **/
     void autoconfigInterrupt(void);


### PR DESCRIPTION
A declaration of the GCONF_PARAMETER "RESET = 0x80" collides with a declaration name "RESET" which is necessary for the STM32F1 series. So I renamed the declaration to ENCODER_RESET, then I can compile for STM32F1.
In file included from C:\Users\mike\Documents\Arduino\BluePill_F103C8_20x4LCD_with_RGB_encoder\BluePill_F103C8_20x4LCD_with_RGB_encoder.ino:3:0:

C:\Users\mike\Documents\Arduino\libraries\ArduinoDuPPaLib-master\src/i2cEncoderLibV2.h:86:12: error: redeclaration of 'RESET'

   RESET =  0x80,

            ^~~~

In file included from C:\Users\mike\AppData\Local\Arduino15\packages\STM32\hardware\stm32\1.5.0\cores\arduino/stm32/stm32_def.h:10:0,

                 from C:\Users\mike\AppData\Local\Arduino15\packages\STM32\hardware\stm32\1.5.0\cores\arduino/stm32/clock.h:43,

                 from C:\Users\mike\AppData\Local\Arduino15\packages\STM32\hardware\stm32\1.5.0\cores\arduino/wiring_time.h:23,

                 from C:\Users\mike\AppData\Local\Arduino15\packages\STM32\hardware\stm32\1.5.0\cores\arduino/wiring.h:38,

                 from C:\Users\mike\AppData\Local\Arduino15\packages\STM32\hardware\stm32\1.5.0\cores\arduino/Arduino.h:32,

                 from sketch\BluePill_F103C8_20x4LCD_with_RGB_encoder.ino.cpp:1:

C:\Users\mike\AppData\Local\Arduino15\packages\STM32\hardware\stm32\1.5.0\system/Drivers/CMSIS/Device/ST/STM32F1xx/Include/stm32f1xx.h:171:3: note: previous declaration 'FlagStatus RESET'

   RESET = 0,

   ^~~~~

exit status 1
Error compiling for board Generic STM32F1 series.