### PR TITLE
Renamed RESET to ENCODER_RESET > name collision

### DIFF
--- a/src/i2cEncoderLibV2.cpp
+++ b/src/i2cEncoderLibV2.cpp
@@ -28,7 +28,7 @@ void i2cEncoderLibV2::begin(uint8_t conf) {
 	_gconf = conf;
 }
 
-void i2cEncoderLibV2::reset(void) {
+void i2cEncoderLibV2::ENCODER_RESET(void) {
 	writeEncoder(REG_GCONF, (uint8_t) 0x80);
 	delay(10);
 }


### PR DESCRIPTION
A declaration of the GCONF_PARAMETER "RESET = 0x80".
collides with a declaration name "RESET" which is necessary for the STM32F1 series. So I renamed the declaration to ENCODER_RESET, then I can compile for STM32F1.